### PR TITLE
Add the Windows/WSL boundary practice — the EOL lesson had no catalog home

### DIFF
--- a/practices/INDEX.md
+++ b/practices/INDEX.md
@@ -34,6 +34,7 @@ Patterns and conventions extracted from production repos. Reference these when s
 
 - [Cloud Run](devops/cloud-run.md) — Two-image pattern, env vars, multi-stage Docker, autoscaling
 - [CI/CD](devops/ci-cd.md) — GitHub Actions, Cloud Build, automated reviews
+- [Windows / WSL Boundary](devops/windows-wsl-boundary.md) — `.gitattributes` line-ending pins, why `git status` can't see CRLF corruption, cross-boundary verification gotchas
 
 ## Finance & Investing
 

--- a/practices/devops/windows-wsl-boundary.md
+++ b/practices/devops/windows-wsl-boundary.md
@@ -1,0 +1,100 @@
+# The Windows / WSL Boundary
+
+Every repo in this stack is edited on Windows and executed under WSL. The boundary
+is quiet until it isn't, and its failures share a shape: **the code is correct, the
+bytes on disk are not, and every tool you would normally trust reports success.**
+
+## Line endings: pin them in `.gitattributes`, per file type
+
+Git for Windows ships `core.autocrlf=true` at *system* scope (`/etc/gitconfig`), so
+it applies even when local and global are unset. Blobs are stored LF and the working
+tree is checked out CRLF.
+
+For a script WSL executes, a CRLF shebang is fatal. The kernel looks for an
+interpreter literally named `/bin/bash\r`:
+
+```
+bash: /mnt/c/.../run_weekly.sh: cannot execute: required file not found
+exit 127
+```
+
+Exit 127 means "command not found", which sends you hunting for a missing binary
+rather than a carriage return.
+
+**Pin what the other side executes:**
+
+```gitattributes
+*.sh  text eol=lf     # WSL bash
+*.py  text eol=lf     # anything with a shebang, or that may gain one
+*.yml text eol=lf     # CI runners
+*.sql text eol=lf     # psql, and anything regex-processed across the boundary
+
+*.ps1 text eol=crlf   # Windows-native — Task Scheduler, wscript.exe
+*.vbs text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+```
+
+### The part that makes it expensive: git cannot see it
+
+`.gitattributes` applies **at checkout**. A file checked out *before* the rule
+existed keeps its CRLF indefinitely, and `git status` stays clean forever — git
+normalizes on read, so the corruption exists only in the working tree. It is
+invisible to code review, to CI, and to `git diff`.
+
+Adding the rule does not fix files already on disk. Refresh them:
+
+```bash
+git rm --cached -r . && git reset --hard   # clean tree only; re-checkouts with attributes applied
+```
+
+Verify by bytes, not by eye — `tr -cd '\r' < file | wc -c` should be 0 for LF files.
+
+### Do not blanket-pin
+
+Pin what the other side *executes*, not everything. Where writers are mixed — an
+editor writing CRLF, rsync/WSL writing LF — a broad `eol=` pin only relocates
+cosmetic `git status` churn without preventing a real failure. crumbl-ops
+deliberately uses `* text=auto` for the index plus targeted pins, and documents the
+refusal in its own `.gitattributes`. "Make every repo's file identical" is the wrong
+generalization.
+
+## Verifying across the boundary: the tools lie in specific ways
+
+- **Don't invoke a WSL path from Git Bash.** MSYS rewrites a bare `/mnt/...`
+  argument into `C:/Program Files/Git/mnt/...`, which the inner shell splits at the
+  space — producing `C:/Program: No such file or directory` and a *fake* failure
+  that mimics the real one. Dispatch from PowerShell or `Start-ScheduledTask`.
+- **A healthy Task Scheduler entry is not evidence.** `State=Ready` and
+  `NumberOfMissedRuns=0` describe the *scheduler*, not the payload. Read
+  `LastTaskResult` (0 = success); a task can fire on time and exit 127 every week
+  while the UI looks green.
+- **`gcloud` working proves nothing about Python.** The client libraries use
+  Application Default Credentials, a separate path. Verify from the venv.
+- **Windows and WSL have different interpreters.** `python` on the Windows PATH is
+  not the WSL venv; a package present in one is absent in the other.
+
+## The rule underneath
+
+A correct fix that lives only in a code comment does not propagate. This lesson
+existed as a comment in two repos' `.gitattributes` and was missing from the third —
+where a weekly scheduled job then returned 127 for two weeks with a clean
+`git status` the entire time. Comments explain *this* file to whoever opens it;
+that is a different job from telling a new repo what to adopt.
+
+## Sources
+
+- 2026-08-10/11, wealth-mgmt: `WM-WeeklyDigest` dead since registration — CRLF
+  shebang in `scripts/run_weekly.sh` (git held LF), diagnosed only by executing it.
+- 2026-05-10, crumbl-ops: CRLF made bash read `set -euo pipefail\r` and silently
+  disable strict mode.
+- crumbl-ops `.gitattributes` (2026-05-29, corrected 2026-08-02) — the measured
+  argument against blanket `eol=` pinning.
+
+## Where Used
+
+- **wealth-mgmt**: `.gitattributes` pins `*.sh`/`*.py` LF, `*.ps1`/`*.vbs` CRLF
+- **crumbl-ops**: `* text=auto` + targeted pins for `*.sh`, `*.yml`, `*.sql`; explicit
+  refusal to pin broadly
+- **best-practices**: `* text=auto eol=lf` + explicit `*.sh`/`*.bash`/`*.py`
+- **command-center**: origin of the fix these mirror


### PR DESCRIPTION
## Why this doc exists

This catalog had **no coverage** of line endings, CRLF, or `.gitattributes` — I grepped. That absence is the story: the lesson existed only as a *comment inside two repos' `.gitattributes` files*, so a third repo had nothing to consult and shipped without it.

`WM-WeeklyDigest` then returned **exit 127 on every run from 2026-07-26 to 2026-08-10** — a CRLF shebang resolving to `/bin/bash\r` — with `git status` clean the entire time, because git normalizes on read and the corruption lived only in the working tree. Invisible to code review, to CI, and to `git diff`.

A comment explains one file to whoever opens it. That's a different job from telling a *new* repo what to adopt, and only the second one propagates.

## What's in it

**1. The pins, per file type** — LF for what WSL executes (`*.sh`, `*.py`, `*.yml`, `*.sql`), CRLF for Windows-native launchers (`*.ps1`, `*.vbs`, `*.bat`, `*.cmd`).

**2. The part that makes it expensive.** `.gitattributes` applies at **checkout**. A file checked out before the rule existed keeps its CRLF indefinitely and no git command will ever report it. Includes the refresh recipe and byte-level verification (`tr -cd '\r' | wc -c`), because "looks fine" is precisely the failure mode.

**3. The counter-case, not a blanket rule.** crumbl-ops deliberately refuses broad `eol=` pinning — its writers are mixed (Edit tool writes CRLF, rsync/WSL write LF), so a pin only relocates cosmetic `git status` churn without preventing a real failure. "Make every repo identical" is the wrong generalization, and the catalog should say so where someone will actually read it.

**4. Cross-boundary verification gotchas** — all hit this session:

- Git Bash rewrites a bare `/mnt/...` argument into `C:/Program Files/Git/mnt/...`, producing a **fake** failure identical to the real one
- Task Scheduler `State=Ready` / `MissedRuns=0` describes the *scheduler*, not the payload — read `LastTaskResult`
- `gcloud` succeeding proves nothing about the Python client's ADC path
- Windows `python` is not the WSL venv

## Notes

**Deliberately not registered** in `digest/config/practice-docs.yaml` — that list is the two living docs `practice_updater` rewrites weekly. This is static reference, so it stays out of the auto-edit loop.

**Verified:** every "Where Used" claim checked against the actual `.gitattributes` in all three repos (they differ, and the doc says how); INDEX link resolves; `## Sources` and `## Where Used` anchors present per house format.
